### PR TITLE
Add Node Health store

### DIFF
--- a/src/dapps/DappsPermissionsStore.spec.js
+++ b/src/dapps/DappsPermissionsStore.spec.js
@@ -41,6 +41,13 @@ test('should handle setPermissions', () => {
   expect(store.permissions).toEqual(mockPermissions);
 });
 
+test('should handle setError', () => {
+  const store = new DappsPermissionsStore(mockApi);
+  store.setError({ message: 'SOME_ERROR' });
+
+  expect(store.error).toEqual({ message: 'SOME_ERROR' });
+});
+
 test('should handle hasAppPermission', () => {
   const store = new DappsPermissionsStore(mockApi);
 

--- a/src/dapps/DappsStore.js
+++ b/src/dapps/DappsStore.js
@@ -21,6 +21,7 @@ let instance = null;
 
 export default class DappsStore {
   @observable apps = [];
+  @observable error = null;
 
   constructor(api) {
     this._api = api;
@@ -41,5 +42,14 @@ export default class DappsStore {
     this.apps = apps;
   };
 
-  loadApps = () => this._api.shell.getApps(false).then(this.setApps);
+  @action
+  setError = error => {
+    this.error = error;
+  };
+
+  loadApps = () =>
+    this._api.shell
+      .getApps(false)
+      .then(this.setApps)
+      .catch(this.setError);
 }

--- a/src/dapps/DappsStore.spec.js
+++ b/src/dapps/DappsStore.spec.js
@@ -47,6 +47,13 @@ test('should handle setApps', () => {
   expect(store.apps).toContainEqual(mockApps[2]);
 });
 
+test('should handle setError', () => {
+  const store = new DappsStore(mockApi);
+  store.setError({ message: 'SOME_ERROR' });
+
+  expect(store.error).toEqual({ message: 'SOME_ERROR' });
+});
+
 test('should make api call when loadApps', () => {
   const getApps = jest.fn(() => Promise.resolve(mockApps));
   const store = new DappsStore({ shell: { getApps } });

--- a/src/dapps/DappsUrlStore.js
+++ b/src/dapps/DappsUrlStore.js
@@ -26,7 +26,11 @@ export default class DappsUrlStore {
   constructor(api) {
     this._api = api;
 
-    this.loadUrl();
+    // Subscribe to Parity pubsub for dappsUrl
+    this._api.pubsub.parity.dappsUrl((error, result) => {
+      this.setError(error);
+      this.setUrl(result);
+    });
   }
 
   static get(api) {
@@ -49,10 +53,4 @@ export default class DappsUrlStore {
   setError = error => {
     this.error = error;
   };
-
-  loadUrl = () =>
-    this._api.parity
-      .dappsUrl()
-      .then(this.setUrl)
-      .catch(this.setError);
 }

--- a/src/dapps/DappsUrlStore.js
+++ b/src/dapps/DappsUrlStore.js
@@ -21,6 +21,7 @@ let instance = null;
 
 export default class DappsUrlStore {
   @observable dappsUrl;
+  @observable error = null;
 
   constructor(api) {
     this._api = api;
@@ -44,5 +45,14 @@ export default class DappsUrlStore {
       : `${window.location.protocol}//${url}`;
   };
 
-  loadUrl = () => this._api.parity.dappsUrl().then(this.setUrl);
+  @action
+  setError = error => {
+    this.error = error;
+  };
+
+  loadUrl = () =>
+    this._api.parity
+      .dappsUrl()
+      .then(this.setUrl)
+      .catch(this.setError);
 }

--- a/src/dapps/DappsUrlStore.spec.js
+++ b/src/dapps/DappsUrlStore.spec.js
@@ -40,6 +40,13 @@ test('should handle setUrl', () => {
   expect(store.dappsUrl).toBe(mockUrl);
 });
 
+test('should handle setError', () => {
+  const store = new DappsUrlStore(mockApi);
+  store.setError({ message: 'SOME_ERROR' });
+
+  expect(store.error).toEqual({ message: 'SOME_ERROR' });
+});
+
 test('should handle setUrl when url does not start with http://', () => {
   const store = new DappsUrlStore(mockApi);
   const partialUrl = '127.0.0.1:1234';

--- a/src/node/NodeHealthStore.js
+++ b/src/node/NodeHealthStore.js
@@ -1,0 +1,88 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { action, computed, observable } from 'mobx';
+
+let instance = null;
+
+export const STATUS_OK = 'ok';
+export const STATUS_WARN = 'needsAttention';
+export const STATUS_BAD = 'bad';
+
+export default class Store {
+  @observable health = {};
+  @observable error;
+
+  constructor(api) {
+    this._api = api;
+
+    // Subscribe to Parity pubsub for nodeHealth
+    this._api.pubsub.parity.nodeHealth((error, result) => {
+      this.setError(error);
+      this.setHealth(result);
+    });
+  }
+
+  static get(api) {
+    if (!instance) {
+      instance = new Store(api);
+    }
+
+    return instance;
+  }
+
+  @computed
+  get overall() {
+    if (!this.health || !Object.keys(this.health).length) {
+      return {
+        status: STATUS_BAD,
+        message: ['Unable to fetch node health.']
+      };
+    }
+
+    // Find out if there are bad statuses
+    const bad = Object.values(this.health)
+      .filter(x => x)
+      .map(({ status }) => status)
+      .find(s => s === STATUS_BAD);
+    // Find out if there are needsAttention statuses
+    const needsAttention = Object.keys(this.health)
+      .filter(key => key !== 'time')
+      .map(key => this.health[key])
+      .filter(x => x)
+      .map(({ status }) => status)
+      .find(s => s === STATUS_WARN);
+    // Get all non-empty messages from all statuses
+    const message = Object.values(this.health)
+      .map(({ message }) => message)
+      .filter(x => x);
+
+    return {
+      status: bad || needsAttention || STATUS_OK,
+      message
+    };
+  }
+
+  @action
+  setHealth = health => {
+    this.health = health;
+  };
+
+  @action
+  setError = error => {
+    this.error = error;
+  };
+}

--- a/src/node/NodeHealthStore.spec.js
+++ b/src/node/NodeHealthStore.spec.js
@@ -1,0 +1,126 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-env jest */
+
+import { toJS } from 'mobx';
+
+import NodeHealthStore, {
+  STATUS_BAD,
+  STATUS_OK,
+  STATUS_WARN
+} from './NodeHealthStore';
+
+const mockHealth = {
+  peers: { details: [], message: '', status: STATUS_OK },
+  sync: { details: true, message: 'not synced', status: STATUS_WARN },
+  time: { details: 234, message: 'bad', status: STATUS_BAD }
+};
+const mockError = { message: 'SOME_ERROR' };
+const mockApi = {
+  pubsub: {
+    parity: {
+      nodeHealth: () => {}
+    }
+  }
+};
+
+test('should be a singleton store when using static get', () => {
+  const store1 = NodeHealthStore.get(mockApi);
+  const store2 = NodeHealthStore.get(mockApi);
+
+  expect(store1).toBe(store2);
+});
+
+test('should handle setHealth', () => {
+  const store = new NodeHealthStore(mockApi);
+  store.setHealth(mockHealth);
+
+  expect(toJS(store.health)).toEqual(mockHealth);
+});
+
+test('should handle setError', () => {
+  const store = new NodeHealthStore(mockApi);
+  store.setError(mockError);
+
+  expect(store.error).toEqual(mockError);
+});
+
+test('should handle overall without health', () => {
+  const store = new NodeHealthStore(mockApi);
+  store.setHealth({});
+
+  expect(store.overall).toEqual({
+    status: STATUS_BAD,
+    message: ['Unable to fetch node health.']
+  });
+});
+
+test('should handle overall bad', () => {
+  const store = new NodeHealthStore(mockApi);
+  store.setHealth({ time: mockHealth.time });
+
+  expect(store.overall).toEqual({ status: STATUS_BAD, message: ['bad'] });
+});
+
+test('should handle overall needsAttention', () => {
+  const store = new NodeHealthStore(mockApi);
+  store.setHealth({ sync: mockHealth.sync });
+
+  expect(store.overall).toEqual({
+    status: STATUS_WARN,
+    message: ['not synced']
+  });
+});
+
+test('should handle overall ok', () => {
+  const store = new NodeHealthStore(mockApi);
+  store.setHealth({ peers: mockHealth.peers });
+
+  expect(store.overall).toEqual({ status: STATUS_OK, message: [] });
+});
+
+test('should set url when pubsub publishes', () => {
+  const mockPubSub = callback => {
+    setTimeout(() => callback(null, mockHealth), 200); // Simulate pubsub with a 200ms timeout
+  };
+  const store = new NodeHealthStore({
+    pubsub: {
+      parity: { nodeHealth: mockPubSub }
+    }
+  });
+
+  expect.assertions(1);
+  return new Promise(resolve => setTimeout(resolve, 200)).then(() => {
+    expect(toJS(store.health)).toEqual(mockHealth);
+  });
+});
+
+test('should set error when pubsub throws error', () => {
+  const mockPubSub = callback => {
+    setTimeout(() => callback(mockError, null), 200); // Simulate pubsub with a 200ms timeout
+  };
+  const store = new NodeHealthStore({
+    pubsub: {
+      parity: { nodeHealth: mockPubSub }
+    }
+  });
+
+  expect.assertions(1);
+  return new Promise(resolve => setTimeout(resolve, 200)).then(() => {
+    expect(store.error).toEqual(mockError);
+  });
+});


### PR DESCRIPTION
- Add error observable in mobx stores, let dapps decide what to do with errors.
- Use pubsub to get parity_dappsUrl in DappsUrlStore
- Add a NodeHealth store which listens (pubsub) to parity_nodeHealth