### PR TITLE
Create Factory Function to create MobX store

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,26 @@ Repo for all Mobx stores used across dapps & plugins
 
 ## List of stores
 
-| Store                 | Description                                          |
-| --------------------- | ---------------------------------------------------- |
-| DappsDisplayStore     | Display information of dapps (visibility, pinned...) |
-| DappsPermissionsStore | Method permissions for dapps                         |
-| DappsStore            | List of all dapps with info                          |
-| DappsUrlStore         | Base url of dapps                                    |
-| HardwareStore         | Hardware wallets                                     |
-| SignerStore           | Signer requests                                      |
+This repo has one store per JSONRPC get/set method pair.
 
-# Folder structure
-
-This repo tries to follow the structure described in `./src/methodGroups.js`.
-
-| Folder    | Method Groups                   | Stores                                                                 |
-| --------- | ------------------------------- | ---------------------------------------------------------------------- |
-| accounts/ | accounts<br>accountsEdit        | HardwareStore                                                          |
-| dapps/    | dapps<br>dappsEdit              | DappsDisplayStore, DappsPermissionsStore,<br>DappsStore, DappsUrlStore |
-| signer/   | signerConfirm<br>signerRequests | SignerStore                                                            |
+| JSONRPC Method (Get)            | JSONRPC Method (Set)                                                                                                        | Store                        |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `eth_accounts`                  |                                                                                                                             | eth/AccountsStore            |
+| `eth_coinbase`                  | `parity_setAuthor`                                                                                                          | eth/CoinbaseStore            |
+| `eth_hashrate`                  |                                                                                                                             | eth/HashrateStore            |
+| `parity_chain`                  |                                                                                                                             | network/ChainStore           |
+| `parity_dappsUrl`               |                                                                                                                             | dapps/DappsUrlStore          |
+| `parity_defaultExtraData`       |                                                                                                                             | mining/DefaultExtraDataStore |
+| `parity_devLogs`                |                                                                                                                             | other/DevLogsStore           |
+| `parity_devLogsLevel`           |                                                                                                                             | other/DevLogsLevelStore      |
+| `parity_enode`                  |                                                                                                                             | network/EnodeStore           |
+| `parity_extraData`              | `parity_setExtraData`                                                                                                       | mining/ExtraDataStore        |
+| `parity_gasFloorTarget`         | `parity_setGasFloorTarget`                                                                                                  | mining/GasFloorTargetStore   |
+| `parity_getBlockHeaderByNumber` |                                                                                                                             | other/LatestBlockStore       |
+| `parity_minGasPrice`            | `parity_setMinGasPrice`                                                                                                     | mining/MinGasPriceStore      |
+| `parity_netPeers`               | `parity_acceptNonReservedPeers`<br>`parity_addReservedPeer`<br>`parity_dropNonReservedPeers`<br>`parity_removeReservedPeer` | network/NetPortStore         |
+| `parity_netPort`                |                                                                                                                             | network/NetPeersStore        |
+| `parity_nodeHealth`             |                                                                                                                             | network/NodeHealthStore      |
+| `parity_rpcSettings`            |                                                                                                                             | network/RpcSettingsStore     |
+| `shell_getApps`                 |                                                                                                                             | dapps/DappsStore             |
+| `shell_getMethodPermissions`    | `shell_setMethodPermissions`                                                                                                | dapps/DappsPermissionsStore  |

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "description": "Parity MobX Stores",
   "version": "1.0.4",
   "main": "lib/index.js",
-  "module": "src/index.js",
-  "jsnext:main": "src/index.js",
+  "module": "lib/index.js",
+  "jsnext:main": "lib/index.js",
   "author": "Parity Team <admin@parity.io>",
   "maintainers": [
     "Jaco Greeff",
@@ -18,17 +18,16 @@
     "type": "git",
     "url": "git+https://github.com/paritytech/js-mobx.git"
   },
-  "keywords": [
-    "Parity",
-    "MobX"
-  ],
+  "keywords": ["Parity", "MobX"],
   "engines": {
     "node": ">=6.11.5"
   },
   "scripts": {
     "build": "babel src --out-dir lib --ignore *.spec.js",
+    "clean": "rimraf lib",
     "ci:makeshift": "makeshift",
     "lint": "semistandard src/",
+    "prebuild": "npm run clean",
     "test": "jest src"
   },
   "publishConfig": {
@@ -41,6 +40,7 @@
     "jest": "^21.2.1",
     "makeshift": "^1.1.0",
     "mobx": "^3.4.1",
+    "rimraf": "^2.6.2",
     "semistandard": "^11.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "type": "git",
     "url": "git+https://github.com/paritytech/js-mobx.git"
   },
-  "keywords": ["Parity", "MobX"],
+  "keywords": [
+    "Parity",
+    "MobX"
+  ],
   "engines": {
     "node": ">=6.11.5"
   },
@@ -26,7 +29,7 @@
     "build": "babel src --out-dir lib --ignore *.spec.js",
     "clean": "rimraf lib",
     "ci:makeshift": "makeshift",
-    "lint": "semistandard src/",
+    "lint": "semistandard --parser babel-eslint src/**/*.js",
     "prebuild": "npm run clean",
     "test": "jest src"
   },
@@ -35,17 +38,18 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-eslint": "^8.1.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-stage-0": "^6.24.1",
     "jest": "^21.2.1",
     "makeshift": "^1.1.0",
     "mobx": "^3.4.1",
     "rimraf": "^2.6.2",
-    "semistandard": "^11.0.0"
+    "semistandard": "^12.0.0"
   },
   "dependencies": {
-    "@parity/ledger": "^2.1.2",
-    "babel-preset-env": "^1.6.1"
+    "@parity/ledger": "^2.1.2"
   },
   "peerDependencies": {
     "mobx": "^3.4.1"

--- a/src/accounts/HardwareStore.js
+++ b/src/accounts/HardwareStore.js
@@ -26,7 +26,7 @@ export default class HardwareStore {
   @observable wallets = {};
   @observable pinMatrixRequest = [];
 
-  constructor(api) {
+  constructor (api) {
     this._api = api;
     this._ledger = Ledger.create(api);
     this._pollId = null;
@@ -40,7 +40,7 @@ export default class HardwareStore {
     });
   }
 
-  isConnected(address) {
+  isConnected (address) {
     return computed(() => !!this.wallets[address]).get();
   }
 
@@ -65,7 +65,7 @@ export default class HardwareStore {
     }, HW_SCAN_INTERVAL);
   };
 
-  scanTrezor() {
+  scanTrezor () {
     return this._api.parity
       .lockedHardwareAccountsInfo()
       .then(paths => {
@@ -82,7 +82,7 @@ export default class HardwareStore {
       });
   }
 
-  scanLedger() {
+  scanLedger () {
     if (!this._ledger.isSupported) {
       return Promise.resolve({});
     }
@@ -109,7 +109,7 @@ export default class HardwareStore {
       });
   }
 
-  _subscribeParity() {
+  _subscribeParity () {
     const onError = error => {
       console.warn('HardwareStore::scanParity', error);
 
@@ -135,7 +135,7 @@ export default class HardwareStore {
       .catch(onError);
   }
 
-  scan() {
+  scan () {
     this.setScanning(true);
     // This only scans for locked devices and does not return open devices,
     // so no need to actually wait for any results here.
@@ -154,11 +154,11 @@ export default class HardwareStore {
     });
   }
 
-  updateWallets() {
+  updateWallets () {
     this.setWallets(Object.assign({}, this.hwAccounts, this.ledgerAccounts));
   }
 
-  createAccountInfo(entry, original = {}) {
+  createAccountInfo (entry, original = {}) {
     const { address, manufacturer, name } = entry;
 
     return Promise.all([
@@ -185,11 +185,11 @@ export default class HardwareStore {
     });
   }
 
-  signLedger(transaction) {
+  signLedger (transaction) {
     return this._ledger.signTransaction(transaction);
   }
 
-  pinMatrixAck(device, passcode) {
+  pinMatrixAck (device, passcode) {
     return this._api.parity
       .hardwarePinMatrixAck(device.path, passcode)
       .then(success => {
@@ -198,7 +198,7 @@ export default class HardwareStore {
       });
   }
 
-  static get(api) {
+  static get (api) {
     if (!instance) {
       instance = new HardwareStore(api);
     }

--- a/src/accounts/index.js
+++ b/src/accounts/index.js
@@ -14,18 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
-
-export { methodGroups, allMethods, methodGroupFromMethod };
-
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export { default as HardwareStore } from './HardwareStore';

--- a/src/dapps/DappsPermissionsStore.js
+++ b/src/dapps/DappsPermissionsStore.js
@@ -23,13 +23,13 @@ export default class DappsPermissionsStore {
   @observable permissions = {};
   @observable error = null;
 
-  constructor(api) {
+  constructor (api) {
     this._api = api;
 
     this.loadPermissions();
   }
 
-  static get(api) {
+  static get (api) {
     if (!instance) {
       instance = new DappsPermissionsStore(api);
     }

--- a/src/dapps/DappsStore.js
+++ b/src/dapps/DappsStore.js
@@ -23,13 +23,13 @@ export default class DappsStore {
   @observable apps = [];
   @observable error = null;
 
-  constructor(api) {
+  constructor (api) {
     this._api = api;
 
     this.loadApps();
   }
 
-  static get(api) {
+  static get (api) {
     if (!instance) {
       instance = new DappsStore(api);
     }

--- a/src/dapps/DappsUrlStore.js
+++ b/src/dapps/DappsUrlStore.js
@@ -23,7 +23,7 @@ export default class DappsUrlStore {
   @observable dappsUrl;
   @observable error = null;
 
-  constructor(api) {
+  constructor (api) {
     this._api = api;
 
     // Subscribe to Parity pubsub for dappsUrl
@@ -33,7 +33,7 @@ export default class DappsUrlStore {
     });
   }
 
-  static get(api) {
+  static get (api) {
     if (!instance) {
       instance = new DappsUrlStore(api);
     }

--- a/src/dapps/DappsUrlStore.spec.js
+++ b/src/dapps/DappsUrlStore.spec.js
@@ -42,13 +42,6 @@ test('should handle setUrl', () => {
   expect(store.dappsUrl).toBe(mockUrl);
 });
 
-test('should handle setError', () => {
-  const store = new DappsUrlStore(mockApi);
-  store.setError({ message: 'SOME_ERROR' });
-
-  expect(store.error).toEqual({ message: 'SOME_ERROR' });
-});
-
 test('should handle setUrl when url does not start with http://', () => {
   const store = new DappsUrlStore(mockApi);
   const partialUrl = '127.0.0.1:1234';

--- a/src/dapps/DappsUrlStore.spec.js
+++ b/src/dapps/DappsUrlStore.spec.js
@@ -42,6 +42,13 @@ test('should handle setUrl', () => {
   expect(store.dappsUrl).toBe(mockUrl);
 });
 
+test('should handle setError', () => {
+  const store = new DappsUrlStore(mockApi);
+  store.setError({ message: 'SOME_ERROR' });
+
+  expect(store.error).toEqual({ message: 'SOME_ERROR' });
+});
+
 test('should handle setUrl when url does not start with http://', () => {
   const store = new DappsUrlStore(mockApi);
   const partialUrl = '127.0.0.1:1234';

--- a/src/dapps/index.js
+++ b/src/dapps/index.js
@@ -14,18 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
-
-export { methodGroups, allMethods, methodGroupFromMethod };
-
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export { default as DappsPermissionsStore } from './DappsPermissionsStore';
+export { default as DappsStore } from './DappsStore';
+export { default as DappsUrlStore } from './DappsUrlStore';

--- a/src/eth/AccountsStore.js
+++ b/src/eth/AccountsStore.js
@@ -14,18 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import createMobxStore from '../utils/createMobxStore';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+const instance = createMobxStore('eth_accounts', {
+  defaultValue: []
+});
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export default instance;

--- a/src/eth/CoinbaseStore.js
+++ b/src/eth/CoinbaseStore.js
@@ -24,7 +24,7 @@ extendObservable(instance, {
   /**
    * Set author
    */
-  setAuthor: function(author) {
+  setAuthor: function (author) {
     return this._api.parity.setAuthor(author);
   }
 });

--- a/src/eth/CoinbaseStore.js
+++ b/src/eth/CoinbaseStore.js
@@ -14,18 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import { extendObservable } from 'mobx';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+import createMobxStore from '../utils/createMobxStore';
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+const instance = createMobxStore('eth_coinbase');
+
+extendObservable(instance, {
+  /**
+   * Set author
+   */
+  setAuthor: function(author) {
+    return this._api.parity.setAuthor(author);
+  }
+});
+
+export default instance;

--- a/src/eth/CoinbaseStore.spec.js
+++ b/src/eth/CoinbaseStore.spec.js
@@ -1,0 +1,34 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-env jest */
+
+import CoinbaseStore from './CoinbaseStore';
+
+test('should handle saveCoinbase', () => {
+  const paritySetAuthor = jest.fn();
+  const store = CoinbaseStore.get({
+    parity: {
+      setAuthor: paritySetAuthor
+    },
+    pubsub: {
+      eth: { coinbase: () => {} }
+    }
+  });
+  store.setAuthor('Foo');
+
+  expect(paritySetAuthor).toHaveBeenCalledWith('Foo');
+});

--- a/src/eth/HashrateStore.js
+++ b/src/eth/HashrateStore.js
@@ -14,18 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import createMobxStore from '../utils/createMobxStore';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+const instance = createMobxStore('eth_hashrate');
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export default instance;

--- a/src/eth/index.js
+++ b/src/eth/index.js
@@ -14,18 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
-
-export { methodGroups, allMethods, methodGroupFromMethod };
-
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export { default as AccountsStore } from './AccountsStore';
+export { default as CoinbaseStore } from './CoinbaseStore';
+export { default as HashrateStore } from './HashrateStore';

--- a/src/mining/DefaultExtraDataStore.js
+++ b/src/mining/DefaultExtraDataStore.js
@@ -14,18 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import createMobxStore from '../utils/createMobxStore';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+const instance = createMobxStore('parity_defaultExtraData');
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export default instance;

--- a/src/mining/ExtraDataStore.js
+++ b/src/mining/ExtraDataStore.js
@@ -24,7 +24,7 @@ extendObservable(instance, {
   /**
    * Save extra data
    */
-  saveExtraData: function(extraData) {
+  saveExtraData: function (extraData) {
     return this._api.parity.setExtraData(extraData);
   }
 });

--- a/src/mining/ExtraDataStore.js
+++ b/src/mining/ExtraDataStore.js
@@ -14,18 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import { extendObservable } from 'mobx';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+import createMobxStore from '../utils/createMobxStore';
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+const instance = createMobxStore('parity_extraData');
+
+extendObservable(instance, {
+  /**
+   * Save extra data
+   */
+  saveExtraData: function(extraData) {
+    return this._api.parity.setExtraData(extraData);
+  }
+});
+
+export default instance;

--- a/src/mining/ExtraDataStore.spec.js
+++ b/src/mining/ExtraDataStore.spec.js
@@ -1,0 +1,34 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-env jest */
+
+import ExtraDataStore from './ExtraDataStore';
+
+test('should handle saveExtraData', () => {
+  const paritySetExtraData = jest.fn();
+  const store = ExtraDataStore.get({
+    parity: {
+      setExtraData: paritySetExtraData
+    },
+    pubsub: {
+      parity: { extraData: () => {} }
+    }
+  });
+  store.saveExtraData('Foo');
+
+  expect(paritySetExtraData).toHaveBeenCalledWith('Foo');
+});

--- a/src/mining/GasFloorTargetStore.js
+++ b/src/mining/GasFloorTargetStore.js
@@ -14,18 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import { extendObservable } from 'mobx';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+import createMobxStore from '../utils/createMobxStore';
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+const instance = createMobxStore('parity_gasFloorTarget');
+
+extendObservable(instance, {
+  /**
+   * Seve gas floor target
+   */
+  saveGasFloorTarget: function(gasFloorTarget) {
+    return this._api.parity.setGasFloorTarget(gasFloorTarget);
+  }
+});
+
+export default instance;

--- a/src/mining/GasFloorTargetStore.js
+++ b/src/mining/GasFloorTargetStore.js
@@ -24,7 +24,7 @@ extendObservable(instance, {
   /**
    * Seve gas floor target
    */
-  saveGasFloorTarget: function(gasFloorTarget) {
+  saveGasFloorTarget: function (gasFloorTarget) {
     return this._api.parity.setGasFloorTarget(gasFloorTarget);
   }
 });

--- a/src/mining/GasFloorTargetStore.spec.js
+++ b/src/mining/GasFloorTargetStore.spec.js
@@ -1,0 +1,34 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-env jest */
+
+import GasFloorTargetStore from './GasFloorTargetStore';
+
+test('should handle saveGasFloorTarget', () => {
+  const paritySetGasFloorTarget = jest.fn();
+  const store = GasFloorTargetStore.get({
+    parity: {
+      setGasFloorTarget: paritySetGasFloorTarget
+    },
+    pubsub: {
+      parity: { gasFloorTarget: () => {} }
+    }
+  });
+  store.saveGasFloorTarget('Foo');
+
+  expect(paritySetGasFloorTarget).toHaveBeenCalledWith('Foo');
+});

--- a/src/mining/MinGasPriceStore.js
+++ b/src/mining/MinGasPriceStore.js
@@ -14,18 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import { extendObservable } from 'mobx';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+import createMobxStore from '../utils/createMobxStore';
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+const instance = createMobxStore('parity_minGasPrice');
+
+extendObservable(instance, {
+  /**
+   * Set minimum gas price
+   */
+  saveMinGasPrice: function(minGasPrice) {
+    return this._api.parity.setMinGasPrice(minGasPrice);
+  }
+});
+
+export default instance;

--- a/src/mining/MinGasPriceStore.js
+++ b/src/mining/MinGasPriceStore.js
@@ -24,7 +24,7 @@ extendObservable(instance, {
   /**
    * Set minimum gas price
    */
-  saveMinGasPrice: function(minGasPrice) {
+  saveMinGasPrice: function (minGasPrice) {
     return this._api.parity.setMinGasPrice(minGasPrice);
   }
 });

--- a/src/mining/MinGasPriceStore.spec.js
+++ b/src/mining/MinGasPriceStore.spec.js
@@ -1,0 +1,34 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-env jest */
+
+import MinGasPriceStore from './MinGasPriceStore';
+
+test('should handle saveMinGasPrice', () => {
+  const paritySetMinGasPrice = jest.fn();
+  const store = MinGasPriceStore.get({
+    parity: {
+      setMinGasPrice: paritySetMinGasPrice
+    },
+    pubsub: {
+      parity: { minGasPrice: () => {} }
+    }
+  });
+  store.saveMinGasPrice('Foo');
+
+  expect(paritySetMinGasPrice).toHaveBeenCalledWith('Foo');
+});

--- a/src/mining/index.js
+++ b/src/mining/index.js
@@ -14,18 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
-
-export { methodGroups, allMethods, methodGroupFromMethod };
-
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export { default as DefaultExtraDataStore } from './DefaultExtraDataStore';
+export { default as ExtraDataStore } from './ExtraDataStore';
+export { default as GasFloorTargetStore } from './GasFloorTargetStore';
+export { default as MinGasPriceStore } from './MinGasPriceStore';

--- a/src/network/ChainStore.js
+++ b/src/network/ChainStore.js
@@ -14,18 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import createMobxStore from '../utils/createMobxStore';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+const instance = createMobxStore('parity_chain');
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export default instance;

--- a/src/network/EnodeStore.js
+++ b/src/network/EnodeStore.js
@@ -14,18 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import createMobxStore from '../utils/createMobxStore';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+const instance = createMobxStore('parity_enode');
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export default instance;

--- a/src/network/NetPeersStore.js
+++ b/src/network/NetPeersStore.js
@@ -1,0 +1,71 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { extendObservable } from 'mobx';
+
+import createMobxStore from '../utils/createMobxStore';
+
+const instance = createMobxStore('parity_netPeers', {
+  defaultValue: {}
+});
+
+extendObservable(instance, {
+  /**
+   * Get real network peers
+   */
+  get realPeers() {
+    if (!this.netPeers.peers) return [];
+    return this.netPeers.peers
+      .filter(({ id }) => id)
+      .filter(
+        ({ network: { remoteAddress } }) => !/handshake/i.test(remoteAddress)
+      )
+      .filter(({ protocols: { eth } }) => eth && eth.head)
+      .sort((peerA, peerB) => {
+        return peerA.id.localeCompare(peerB.id);
+      });
+  },
+
+  /**
+   * Accept non-reserved peers
+   */
+  acceptNonReservedPeers: function() {
+    return this._api.parity.acceptNonReservedPeers();
+  },
+
+  /**
+   * Add reserved peers
+   */
+  addReservedPeer: function(enode) {
+    return this._api.parity.addReservedPeer(enode);
+  },
+
+  /**
+   * Drop non-reserved peers
+   */
+  dropNonReservedPeers: function() {
+    return this._api.parity.dropNonReservedPeers();
+  },
+
+  /**
+   * Remove reserved peers
+   */
+  removeReservedPeer: function(enode) {
+    return this._api.parity.removeReservedPeer(enode);
+  }
+});
+
+export default instance;

--- a/src/network/NetPeersStore.js
+++ b/src/network/NetPeersStore.js
@@ -26,7 +26,7 @@ extendObservable(instance, {
   /**
    * Get real network peers
    */
-  get realPeers() {
+  get realPeers () {
     if (!this.netPeers.peers) return [];
     return this.netPeers.peers
       .filter(({ id }) => id)
@@ -42,28 +42,28 @@ extendObservable(instance, {
   /**
    * Accept non-reserved peers
    */
-  acceptNonReservedPeers: function() {
+  acceptNonReservedPeers: function () {
     return this._api.parity.acceptNonReservedPeers();
   },
 
   /**
    * Add reserved peers
    */
-  addReservedPeer: function(enode) {
+  addReservedPeer: function (enode) {
     return this._api.parity.addReservedPeer(enode);
   },
 
   /**
    * Drop non-reserved peers
    */
-  dropNonReservedPeers: function() {
+  dropNonReservedPeers: function () {
     return this._api.parity.dropNonReservedPeers();
   },
 
   /**
    * Remove reserved peers
    */
-  removeReservedPeer: function(enode) {
+  removeReservedPeer: function (enode) {
     return this._api.parity.removeReservedPeer(enode);
   }
 });

--- a/src/network/NetPeersStore.spec.js
+++ b/src/network/NetPeersStore.spec.js
@@ -1,0 +1,106 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-env jest */
+
+import { toJS } from 'mobx';
+
+import NetPeersStore from './NetPeersStore';
+
+const mockApi = {
+  pubsub: {
+    parity: { netPeers: () => {} }
+  },
+  parity: {
+    acceptNonReservedPeers: jest.fn(),
+    addReservedPeer: jest.fn(),
+    dropNonReservedPeers: jest.fn(),
+    removeReservedPeer: jest.fn()
+  }
+};
+
+test('should handle realPeers when netPeers is not set', () => {
+  const store = NetPeersStore.get(mockApi);
+
+  expect(toJS(store.realPeers)).toEqual([]);
+});
+
+test('should handle realPeers correctly', () => {
+  const store = NetPeersStore.get(mockApi);
+  const realPeers = [
+    {
+      id: '4',
+      network: { remoteAddress: 'Foo' },
+      protocols: {
+        eth: {
+          head: 'Foo'
+        }
+      }
+    },
+    {
+      id: '5',
+      network: { remoteAddress: 'Foo' },
+      protocols: {
+        eth: {
+          head: 'Bar'
+        }
+      }
+    }
+  ];
+  store.setNetPeers({
+    peers: [
+      { id: null }, // To be removed because no id
+      { id: '1', network: { remoteAddress: 'Handshake' } }, // To be removed because handshake
+      { id: '2', network: { remoteAddress: 'Foo' }, protocols: {} }, // To be removed because no protocols.eth
+      {
+        id: '3', // To be removed because no protocol.eth.head
+        network: { remoteAddress: 'Handshake' },
+        protocols: { eth: {} }
+      },
+      ...realPeers.slice().reverse() // Setting in reverse to test sort
+    ]
+  });
+
+  expect(toJS(store.realPeers)).toEqual(realPeers);
+});
+
+test('should handle acceptNonReservedPeers', () => {
+  const store = NetPeersStore.get(mockApi);
+  store.acceptNonReservedPeers();
+
+  expect(mockApi.parity.acceptNonReservedPeers).toHaveBeenCalledWith();
+});
+
+test('should handle addReservedPeer', () => {
+  const store = NetPeersStore.get(mockApi);
+  store.addReservedPeer('Foo');
+
+  expect(mockApi.parity.addReservedPeer).toHaveBeenCalledWith('Foo');
+});
+
+test('should handle dropNonReservedPeers', () => {
+  const store = NetPeersStore.get(mockApi);
+  store.dropNonReservedPeers();
+
+  expect(mockApi.parity.dropNonReservedPeers).toHaveBeenCalledWith();
+});
+
+test('should handle removeReservedPeer', () => {
+  const store = NetPeersStore.get(mockApi);
+  store.removeReservedPeer('Foo');
+
+  expect(mockApi.parity.removeReservedPeer).toHaveBeenCalledWith('Foo');
+});

--- a/src/network/NetPortStore.js
+++ b/src/network/NetPortStore.js
@@ -14,18 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import createMobxStore from '../utils/createMobxStore';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+const instance = createMobxStore('parity_netPort');
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export default instance;

--- a/src/network/RpcSettingsStore.js
+++ b/src/network/RpcSettingsStore.js
@@ -14,18 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import createMobxStore from '../utils/createMobxStore';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+const instance = createMobxStore('parity_rpcSettings');
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export default instance;

--- a/src/network/index.js
+++ b/src/network/index.js
@@ -14,18 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
-
-export { methodGroups, allMethods, methodGroupFromMethod };
-
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export { default as ChainStore } from './ChainStore';
+export { default as EnodeStore } from './EnodeStore';
+export { default as NetPeersStore } from './NetPeersStore';
+export { default as NetPortStore } from './NetPortStore';
+export { default as RpcSettingsStore } from './RpcSettingsStore';

--- a/src/node/NodeHealthStore.js
+++ b/src/node/NodeHealthStore.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import { computed, extendObservable } from 'mobx';
+import { extendObservable } from 'mobx';
 
 import createMobxStore from '../utils/createMobxStore';
 
@@ -31,7 +31,7 @@ extendObservable(instance, {
   /**
    * Get overall health of node
    */
-  get overall() {
+  get overall () {
     if (!this.health || !Object.keys(this.health).length) {
       return {
         status: STATUS_BAD,

--- a/src/node/NodeHealthStore.js
+++ b/src/node/NodeHealthStore.js
@@ -14,37 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import { action, computed, observable } from 'mobx';
+import { computed, extendObservable } from 'mobx';
 
-let instance = null;
+import createMobxStore from '../utils/createMobxStore';
 
 export const STATUS_OK = 'ok';
 export const STATUS_WARN = 'needsAttention';
 export const STATUS_BAD = 'bad';
 
-export default class Store {
-  @observable health = {};
-  @observable error;
+const instance = createMobxStore('parity_nodeHealth', {
+  variableName: 'health',
+  defaultValue: {}
+});
 
-  constructor(api) {
-    this._api = api;
-
-    // Subscribe to Parity pubsub for nodeHealth
-    this._api.pubsub.parity.nodeHealth((error, result) => {
-      this.setError(error);
-      this.setHealth(result);
-    });
-  }
-
-  static get(api) {
-    if (!instance) {
-      instance = new Store(api);
-    }
-
-    return instance;
-  }
-
-  @computed
+extendObservable(instance, {
+  /**
+   * Get overall health of node
+   */
   get overall() {
     if (!this.health || !Object.keys(this.health).length) {
       return {
@@ -75,14 +61,6 @@ export default class Store {
       message
     };
   }
+});
 
-  @action
-  setHealth = health => {
-    this.health = health;
-  };
-
-  @action
-  setError = error => {
-    this.error = error;
-  };
-}
+export default instance;

--- a/src/node/NodeHealthStore.spec.js
+++ b/src/node/NodeHealthStore.spec.js
@@ -38,29 +38,8 @@ const mockApi = {
   }
 };
 
-test('should be a singleton store when using static get', () => {
-  const store1 = NodeHealthStore.get(mockApi);
-  const store2 = NodeHealthStore.get(mockApi);
-
-  expect(store1).toBe(store2);
-});
-
-test('should handle setHealth', () => {
-  const store = new NodeHealthStore(mockApi);
-  store.setHealth(mockHealth);
-
-  expect(toJS(store.health)).toEqual(mockHealth);
-});
-
-test('should handle setError', () => {
-  const store = new NodeHealthStore(mockApi);
-  store.setError(mockError);
-
-  expect(store.error).toEqual(mockError);
-});
-
 test('should handle overall without health', () => {
-  const store = new NodeHealthStore(mockApi);
+  const store = NodeHealthStore.get(mockApi);
   store.setHealth({});
 
   expect(store.overall).toEqual({
@@ -70,14 +49,14 @@ test('should handle overall without health', () => {
 });
 
 test('should handle overall bad', () => {
-  const store = new NodeHealthStore(mockApi);
+  const store = NodeHealthStore.get(mockApi);
   store.setHealth({ time: mockHealth.time });
 
   expect(store.overall).toEqual({ status: STATUS_BAD, message: ['bad'] });
 });
 
 test('should handle overall needsAttention', () => {
-  const store = new NodeHealthStore(mockApi);
+  const store = NodeHealthStore.get(mockApi);
   store.setHealth({ sync: mockHealth.sync });
 
   expect(store.overall).toEqual({
@@ -87,40 +66,8 @@ test('should handle overall needsAttention', () => {
 });
 
 test('should handle overall ok', () => {
-  const store = new NodeHealthStore(mockApi);
+  const store = NodeHealthStore.get(mockApi);
   store.setHealth({ peers: mockHealth.peers });
 
   expect(store.overall).toEqual({ status: STATUS_OK, message: [] });
-});
-
-test('should set url when pubsub publishes', () => {
-  const mockPubSub = callback => {
-    setTimeout(() => callback(null, mockHealth), 200); // Simulate pubsub with a 200ms timeout
-  };
-  const store = new NodeHealthStore({
-    pubsub: {
-      parity: { nodeHealth: mockPubSub }
-    }
-  });
-
-  expect.assertions(1);
-  return new Promise(resolve => setTimeout(resolve, 200)).then(() => {
-    expect(toJS(store.health)).toEqual(mockHealth);
-  });
-});
-
-test('should set error when pubsub throws error', () => {
-  const mockPubSub = callback => {
-    setTimeout(() => callback(mockError, null), 200); // Simulate pubsub with a 200ms timeout
-  };
-  const store = new NodeHealthStore({
-    pubsub: {
-      parity: { nodeHealth: mockPubSub }
-    }
-  });
-
-  expect.assertions(1);
-  return new Promise(resolve => setTimeout(resolve, 200)).then(() => {
-    expect(store.error).toEqual(mockError);
-  });
 });

--- a/src/node/NodeHealthStore.spec.js
+++ b/src/node/NodeHealthStore.spec.js
@@ -16,8 +16,6 @@
 
 /* eslint-env jest */
 
-import { toJS } from 'mobx';
-
 import NodeHealthStore, {
   STATUS_BAD,
   STATUS_OK,
@@ -29,7 +27,6 @@ const mockHealth = {
   sync: { details: true, message: 'not synced', status: STATUS_WARN },
   time: { details: 234, message: 'bad', status: STATUS_BAD }
 };
-const mockError = { message: 'SOME_ERROR' };
 const mockApi = {
   pubsub: {
     parity: {

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -14,18 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
-
-export { methodGroups, allMethods, methodGroupFromMethod };
-
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export { default as NodeHealthStore } from './NodeHealthStore';

--- a/src/other/DevLogsLevelsStore.js
+++ b/src/other/DevLogsLevelsStore.js
@@ -14,18 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import createMobxStore from '../utils/createMobxStore';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+const instance = createMobxStore('parity_devLogsLevels');
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export default instance;

--- a/src/other/DevLogsStore.js
+++ b/src/other/DevLogsStore.js
@@ -1,0 +1,65 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { action, observable } from 'mobx';
+
+let instance = null;
+
+export default class DevLogsStore {
+  @observable devLogs = [];
+  @observable error = null;
+  @observable parsedLogs = [];
+
+  constructor(api) {
+    this._api = api;
+
+    this._api.pubsub.parity.devLogs((error, devLogs) => {
+      this.setError(error);
+      this.setDevLogs(devLogs); // Gets last 128 logs, unparsed
+      this.addParsedLog(devLogs[0]); // Parse the most recent one, not using @computed to avoid parsing too much data
+    });
+  }
+
+  static get(api) {
+    if (!instance) {
+      instance = new DevLogsStore(api);
+    }
+
+    return instance;
+  }
+
+  @action
+  addParsedLog = log => {
+    const parsedLog = /^(\d{4}.\d{2}.\d{2}.\d{2}.\d{2}.\d{2})(.*)$/i.exec(log); // Get the date inside the log
+    if (!parsedLog) return;
+    this.parsedLogs.replace(
+      this.parsedLogs.concat({
+        date: parsedLog[1],
+        log: parsedLog[2]
+      })
+    );
+  };
+
+  @action
+  setDevLogs = devLogs => {
+    this.devLogs = devLogs;
+  };
+
+  @action
+  setError = error => {
+    this.error = error;
+  };
+}

--- a/src/other/DevLogsStore.js
+++ b/src/other/DevLogsStore.js
@@ -23,7 +23,7 @@ export default class DevLogsStore {
   @observable error = null;
   @observable parsedLogs = [];
 
-  constructor(api) {
+  constructor (api) {
     this._api = api;
 
     this._api.pubsub.parity.devLogs((error, devLogs) => {
@@ -33,7 +33,7 @@ export default class DevLogsStore {
     });
   }
 
-  static get(api) {
+  static get (api) {
     if (!instance) {
       instance = new DevLogsStore(api);
     }

--- a/src/other/DevLogsStore.spec.js
+++ b/src/other/DevLogsStore.spec.js
@@ -1,0 +1,112 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-env jest */
+
+import { toJS } from 'mobx';
+
+import DevLogsStore from './DevLogsStore';
+
+const mockDevLogs = [
+  '2018-01-03 10:35:58 9/25 peers 6 MiB chain 67 MiB db 0 bytes queue 2 MiB sync RPC: 1 conn, 5 req/s, 198 µs',
+  'Second Log'
+];
+const mockError = { message: 'SOME_ERROR' };
+const mockApi = {
+  pubsub: {
+    parity: {
+      devLogs: () => {}
+    }
+  }
+};
+
+test('should be a singleton store when using static get', () => {
+  const store1 = DevLogsStore.get(mockApi);
+  const store2 = DevLogsStore.get(mockApi);
+
+  expect(store1).toBe(store2);
+});
+
+test('should handle addParsedLog', () => {
+  const store = new DevLogsStore(mockApi);
+  store.addParsedLog(mockDevLogs[0]);
+
+  expect(store.parsedLogs[0]).toEqual({
+    date: '2018-01-03 10:35:58',
+    log:
+      ' 9/25 peers 6 MiB chain 67 MiB db 0 bytes queue 2 MiB sync RPC: 1 conn, 5 req/s, 198 µs'
+  });
+});
+
+test('should skip addParsedLog if log not parseable', () => {
+  const store = new DevLogsStore(mockApi);
+  store.addParsedLog(mockDevLogs[1]);
+
+  expect(store.parsedLogs).toHaveLength(0);
+});
+
+test('should handle setDevLogs', () => {
+  const store = new DevLogsStore(mockApi);
+  store.setDevLogs(mockDevLogs);
+
+  expect(toJS(store.devLogs)).toEqual(mockDevLogs);
+});
+
+test('should handle setError', () => {
+  const store = new DevLogsStore(mockApi);
+  store.setError(mockError);
+
+  expect(store.error).toEqual(mockError);
+});
+
+test('should setDevLogs when pubsub publishes', () => {
+  const mockPubSub = callback => {
+    setTimeout(() => callback(null, mockDevLogs), 200); // Simulate pubsub with a 200ms timeout
+  };
+  const store = new DevLogsStore({
+    pubsub: {
+      parity: { devLogs: mockPubSub }
+    }
+  });
+
+  expect.assertions(2);
+  return new Promise(resolve => setTimeout(resolve, 200)).then(() => {
+    expect(toJS(store.devLogs)).toEqual(mockDevLogs);
+    expect(toJS(store.parsedLogs)).toEqual([
+      {
+        date: '2018-01-03 10:35:58',
+        log:
+          ' 9/25 peers 6 MiB chain 67 MiB db 0 bytes queue 2 MiB sync RPC: 1 conn, 5 req/s, 198 µs'
+      }
+    ]);
+  });
+});
+
+test('should set error when pubsub throws error', () => {
+  const mockPubSub = callback => {
+    setTimeout(() => callback(mockError, null), 200); // Simulate pubsub with a 200ms timeout
+  };
+  const store = new DevLogsStore({
+    pubsub: {
+      parity: { devLogs: mockPubSub }
+    }
+  });
+
+  expect.assertions(1);
+  return new Promise(resolve => setTimeout(resolve, 200)).then(() => {
+    expect(store.error).toEqual(mockError);
+  });
+});

--- a/src/other/LatestBlockStore.js
+++ b/src/other/LatestBlockStore.js
@@ -14,18 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
+import createMobxStore from '../utils/createMobxStore';
 
-export { methodGroups, allMethods, methodGroupFromMethod };
+const instance = createMobxStore('parity_getBlockHeaderByNumber', {
+  variableName: 'latestBlock',
+  defaultValue: {},
+  displayName: 'LatestBlockStore'
+});
 
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export default instance;

--- a/src/other/index.js
+++ b/src/other/index.js
@@ -14,18 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
-
-export { methodGroups, allMethods, methodGroupFromMethod };
-
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export { default as DevLogsLevelsStore } from './DevLogsLevelsStore';
+export { default as DevLogsStore } from './DevLogsStore';
+export { default as LatestBlockStore } from './LatestBlockStore';

--- a/src/signer/SignerStore.js
+++ b/src/signer/SignerStore.js
@@ -23,7 +23,7 @@ export default class SignerStore {
 
   externalLink = '';
 
-  constructor(api, withLocalTransactions = false, externalLink = '') {
+  constructor (api, withLocalTransactions = false, externalLink = '') {
     this._api = api;
     this._timeoutId = 0;
     this.externalLink = externalLink;
@@ -52,13 +52,13 @@ export default class SignerStore {
   };
 
   @action
-  unsubscribe() {
+  unsubscribe () {
     if (this._timeoutId) {
       clearTimeout(this._timeoutId);
     }
   }
 
-  fetchBalance(address) {
+  fetchBalance (address) {
     this._api.eth
       .getBalance(address)
       .then(balance => {
@@ -69,7 +69,7 @@ export default class SignerStore {
       });
   }
 
-  fetchBalances(_addresses) {
+  fetchBalances (_addresses) {
     const addresses = _addresses.filter(address => address) || [];
 
     if (!addresses.length) {

--- a/src/signer/index.js
+++ b/src/signer/index.js
@@ -14,18 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import methodGroups, {
-  allMethods,
-  methodGroupFromMethod
-} from './methodGroups';
-
-export { methodGroups, allMethods, methodGroupFromMethod };
-
-export * from './accounts';
-export * from './dapps';
-export * from './eth';
-export * from './mining';
-export * from './network';
-export * from './node';
-export * from './other';
-export * from './signer';
+export { default as SignerStore } from './SignerStore';

--- a/src/utils/capitalize.js
+++ b/src/utils/capitalize.js
@@ -1,0 +1,23 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Capitalize the first letter of a string
+ * @param {String} str The string to work on
+ */
+const capitalize = str => str.charAt(0).toUpperCase() + str.substring(1);
+
+export default capitalize;

--- a/src/utils/capitalize.spec.js
+++ b/src/utils/capitalize.spec.js
@@ -1,0 +1,27 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-env jest */
+
+import capitalize from './capitalize';
+
+test('should capitalize correctly', () => {
+  expect(capitalize('foo')).toBe('Foo');
+});
+
+test('should leave it if already capitalized', () => {
+  expect(capitalize('BAR')).toBe('BAR');
+});

--- a/src/utils/createMobxStore.js
+++ b/src/utils/createMobxStore.js
@@ -41,14 +41,14 @@ const createMobxStore = (jsonRpcMethod, storeOptions = {}) => {
      * Action setter for the main variable of the store
      * E.g. in NodeHealthStore, this would be @action setHealth()
      */
-    [`set${capitalize(options.variableName)}`]: action(function(result) {
+    [`set${capitalize(options.variableName)}`]: action(function (result) {
       this[options.variableName] = result;
     }),
 
     /**
      * Action setter for the error
      */
-    setError: action(function(error) {
+    setError: action(function (error) {
       this.error = error;
     }),
 
@@ -56,7 +56,7 @@ const createMobxStore = (jsonRpcMethod, storeOptions = {}) => {
      * The public getter to access the Mobx store
      * @param {Object} api The @parity/api object
      */
-    get(api) {
+    get (api) {
       if (!this[options.variableName]) {
         // We are enforcing Mobx stores to be singletons. If we didn't populate
         // the current store with the main variable, then it's the 1st time the

--- a/src/utils/createMobxStore.js
+++ b/src/utils/createMobxStore.js
@@ -1,0 +1,82 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { action, extendObservable } from 'mobx';
+
+import capitalize from './capitalize';
+
+/**
+ * Factory function to create a MobX store that listens to (as in pubsub) a JSONRPC method
+ * @param {String} jsonRpcMethod The JSONRPC method to create a MobX store for
+ * @param {Object} storeOptions Optional options to pass when creating the MobX store
+ */
+const createMobxStore = (jsonRpcMethod, storeOptions = {}) => {
+  // Split the JSONRPC method into namespace and method
+  // E.g. parity_nodeHealth -> ['parity', 'nodeHealth']
+  const [namespace, method] = jsonRpcMethod.split('_');
+
+  // Default options for MobX store
+  const options = {
+    variableName: method, // The name of the variable to track inside the store, e.g. "health" in nodeHealthStore.health
+    defaultValue: null, // The initial value of that variable
+    displayName: `${capitalize(method)}Store`, // A nice name for the store, not used for now
+    ...storeOptions
+  };
+
+  return {
+    /**
+     * Action setter for the main variable of the store
+     * E.g. in NodeHealthStore, this would be @action setHealth()
+     */
+    [`set${capitalize(options.variableName)}`]: action(function(result) {
+      this[options.variableName] = result;
+    }),
+
+    /**
+     * Action setter for the error
+     */
+    setError: action(function(error) {
+      this.error = error;
+    }),
+
+    /**
+     * The public getter to access the Mobx store
+     * @param {Object} api The @parity/api object
+     */
+    get(api) {
+      if (!this[options.variableName]) {
+        // We are enforcing Mobx stores to be singletons. If we didn't populate
+        // the current store with the main variable, then it's the 1st time the
+        // user is accessing the store, so we populate with observables.
+        extendObservable(this, {
+          [options.variableName]: options.defaultValue,
+          error: null
+        });
+
+        this._api = api;
+
+        // Subscribe to Parity pubsub
+        this._api.pubsub[namespace][method]((error, result) => {
+          this.setError(error);
+          this[`set${capitalize(options.variableName)}`](result);
+        });
+      }
+      return this;
+    }
+  };
+};
+
+export default createMobxStore;

--- a/src/utils/createMobxStore.spec.js
+++ b/src/utils/createMobxStore.spec.js
@@ -1,0 +1,100 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-env jest */
+
+import { toJS } from 'mobx';
+
+import createMobxStore from './createMobxStore';
+
+// Mocks
+const mockResult = {
+  peers: { details: [], message: '' },
+  sync: { details: true, message: 'not synced' },
+  time: { details: 234, message: 'bad' }
+};
+const mockError = { message: 'SOME_ERROR' };
+const mockJsonrpcMethod = 'parity_fakeVariable';
+const mockApi = {
+  pubsub: {
+    parity: {
+      fakeVariable: () => {} // Mock an API for parity_fakeVariable
+    }
+  }
+};
+
+test('should be a singleton store when using static get', () => {
+  const baseStore = createMobxStore(mockJsonrpcMethod);
+  const store1 = baseStore.get(mockApi);
+  const store2 = baseStore.get(mockApi);
+
+  expect(store1).toBe(store2);
+});
+
+test('should handle store options', () => {
+  const store = createMobxStore(mockJsonrpcMethod, {
+    variableName: 'foo',
+    defaultValue: 'bar'
+  }).get(mockApi);
+
+  expect(store.foo).toBe('bar');
+});
+
+test('should handle setResult', () => {
+  const store = createMobxStore(mockJsonrpcMethod).get(mockApi);
+  store.setFakeVariable(mockResult);
+
+  expect(toJS(store.fakeVariable)).toEqual(mockResult);
+});
+
+test('should handle setError', () => {
+  const store = createMobxStore(mockJsonrpcMethod).get(mockApi);
+  store.setError(mockError);
+
+  expect(toJS(store.error)).toEqual(mockError);
+});
+
+test('should setResult when pubsub publishes', () => {
+  const mockPubSub = callback => {
+    setTimeout(() => callback(null, mockResult), 200); // Simulate pubsub with a 200ms timeout
+  };
+  const store = createMobxStore(mockJsonrpcMethod).get({
+    pubsub: {
+      parity: { fakeVariable: mockPubSub }
+    }
+  });
+
+  expect.assertions(1);
+  return new Promise(resolve => setTimeout(resolve, 200)).then(() => {
+    expect(toJS(store.fakeVariable)).toEqual(mockResult);
+  });
+});
+
+test('should setError when pubsub throws error', () => {
+  const mockPubSub = callback => {
+    setTimeout(() => callback(mockError, null), 200); // Simulate pubsub with a 200ms timeout
+  };
+  const store = createMobxStore(mockJsonrpcMethod).get({
+    pubsub: {
+      parity: { fakeVariable: mockPubSub }
+    }
+  });
+
+  expect.assertions(1);
+  return new Promise(resolve => setTimeout(resolve, 200)).then(() => {
+    expect(store.error).toEqual(mockError);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,59 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz#473d021ecc573a2cce1c07d5b509d5215f46ba35"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/helper-function-name@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz#afe63ad799209989348b1109b44feb66aa245f57"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.31"
+    "@babel/template" "7.0.0-beta.31"
+    "@babel/traverse" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+
+"@babel/helper-get-function-arity@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz#1176d79252741218e0aec872ada07efb2b37a493"
+  dependencies:
+    "@babel/types" "7.0.0-beta.31"
+
+"@babel/template@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.31.tgz#577bb29389f6c497c3e7d014617e7d6713f68bda"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
+    lodash "^4.2.0"
+
+"@babel/traverse@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.31.tgz#db399499ad74aefda014f0c10321ab255134b1df"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/helper-function-name" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
+    debug "^3.0.1"
+    globals "^10.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.31.tgz#42c9c86784f674c173fb21882ca9643334029de4"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 "@parity/ledger@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@parity/ledger/-/ledger-2.1.2.tgz#d7f27b5c6084cda8dc38e1333454a67c752496a0"
@@ -43,11 +96,11 @@ acorn@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
-ajv-keywords@^1.0.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+ajv-keywords@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
-ajv@^4.7.0, ajv@^4.9.1:
+ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
@@ -57,6 +110,15 @@ ajv@^4.7.0, ajv@^4.9.1:
 ajv@^5.1.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ajv@^5.2.3, ajv@^5.3.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -74,10 +136,6 @@ align-text@^0.1.1, align-text@^0.1.3:
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-
-ansi-escapes@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
 ansi-escapes@^3.0.0:
   version "3.0.0"
@@ -145,6 +203,13 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -159,16 +224,13 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
-array.prototype.find@^2.0.1:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.4.tgz#556a5c5362c08648323ddaeb9de9d14bc1864c90"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.7.0"
-
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 asn1@~0.2.3:
   version "0.2.3"
@@ -237,7 +299,7 @@ babel-cli@^6.26.0:
   optionalDependencies:
     chokidar "^1.6.1"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
+babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -268,6 +330,17 @@ babel-core@^6.0.0, babel-core@^6.0.14, babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-eslint@^8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.1.2.tgz#a39230b0c20ecbaa19a35d5633bf9b9ca2c8116f"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/traverse" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
+    eslint-scope "~3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.0"
@@ -920,6 +993,10 @@ babelify@^7.3.0:
     babel-core "^6.0.14"
     object-assign "^4.0.0"
 
+babylon@7.0.0-beta.31:
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
+
 babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
@@ -1021,11 +1098,11 @@ browserify-aes@^1.0.6:
     safe-buffer "^5.0.1"
 
 browserslist@^2.1.2:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.10.0.tgz#bac5ee1cc69ca9d96403ffb8a3abdc5b6aed6346"
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.0.tgz#50350d6873a82ebe0f3ae5483658c571ae5f9d7d"
   dependencies:
-    caniuse-lite "^1.0.30000780"
-    electron-to-chromium "^1.3.28"
+    caniuse-lite "^1.0.30000784"
+    electron-to-chromium "^1.3.30"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -1063,9 +1140,9 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-caniuse-lite@^1.0.30000780:
-  version "1.0.30000783"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000783.tgz#9b5499fb1b503d2345d12aa6b8612852f4276ffd"
+caniuse-lite@^1.0.30000784:
+  version "1.0.30000784"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000784.tgz#129ced74e9a1280a441880b6cd2bce30ef59e6c0"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1078,7 +1155,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1088,13 +1165,17 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
 chokidar@^1.6.1:
   version "1.7.0"
@@ -1126,11 +1207,11 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
-cli-cursor@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
-    restore-cursor "^1.0.1"
+    restore-cursor "^2.0.0"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -1184,7 +1265,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.2:
+concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1207,6 +1288,10 @@ content-type-parser@^1.0.1:
 convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
+
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.3"
@@ -1236,7 +1321,7 @@ create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -1266,12 +1351,6 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
-d@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
-  dependencies:
-    es5-ext "^0.10.9"
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1282,13 +1361,13 @@ debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@^2.1.1, debug@^2.2.0, debug@^2.6.8:
+debug@^2.2.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -1364,14 +1443,14 @@ diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
-doctrine@1.5.0, doctrine@^1.2.2:
+doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0:
+doctrine@^2.0.0, doctrine@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
   dependencies:
@@ -1391,9 +1470,15 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-electron-to-chromium@^1.3.28:
-  version "1.3.28"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz#8dd4e6458086644e9f9f0a1cf32e2a1f9dffd9ee"
+electron-releases@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/electron-releases/-/electron-releases-2.1.0.tgz#c5614bf811f176ce3c836e368a0625782341fd4e"
+
+electron-to-chromium@^1.3.30:
+  version "1.3.30"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz#9666f532a64586651fc56a72513692e820d06a80"
+  dependencies:
+    electron-releases "^2.1.0"
 
 elliptic@^6.2.3:
   version "6.4.0"
@@ -1406,6 +1491,12 @@ elliptic@^6.2.3:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
 
 errno@^0.1.4:
   version "0.1.6"
@@ -1437,58 +1528,6 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
-es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.37"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.37.tgz#0ee741d148b80069ba27d020393756af257defc3"
-  dependencies:
-    es6-iterator "~2.0.1"
-    es6-symbol "~3.1.1"
-
-es6-iterator@^2.0.1, es6-iterator@~2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-map@^0.1.3:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-set "~0.1.5"
-    es6-symbol "~3.1.1"
-    event-emitter "~0.3.5"
-
-es6-set@~0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-symbol "3.1.1"
-    event-emitter "~0.3.5"
-
-es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-es6-weak-map@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.14"
-    es6-iterator "^2.0.1"
-    es6-symbol "^3.1.1"
-
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -1504,126 +1543,127 @@ escodegen@^1.6.1:
   optionalDependencies:
     source-map "~0.5.6"
 
-escope@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+eslint-config-semistandard@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-semistandard/-/eslint-config-semistandard-12.0.0.tgz#e6482de68e05c2dbdddaf45c3078f6a97fe23f1a"
+
+eslint-config-standard-jsx@~4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz#009e53c4ddb1e9ee70b4650ffe63a7f39f8836e1"
+
+eslint-config-standard@11.0.0-beta.0:
+  version "11.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-11.0.0-beta.0.tgz#f8afe69803d95c685a4b8392b8793188eb03cbb3"
+
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz#4422574cde66a9a7b099938ee4d508a199e0e3cc"
   dependencies:
-    es6-map "^0.1.3"
-    es6-weak-map "^2.0.1"
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
+    debug "^2.6.8"
+    resolve "^1.2.0"
 
-eslint-config-semistandard@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-semistandard/-/eslint-config-semistandard-11.0.0.tgz#44eef7cfdfd47219e3a7b81b91b540e880bb2615"
-
-eslint-config-standard-jsx@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.1.tgz#cd4e463d0268e2d9e707f61f42f73f5b3333c642"
-
-eslint-config-standard@^10.2.1:
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz#c061e4d066f379dc17cd562c64e819b4dd454591"
-
-eslint-import-resolver-node@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
-  dependencies:
-    debug "^2.2.0"
-    object-assign "^4.0.1"
-    resolve "^1.1.6"
-
-eslint-module-utils@^2.0.0:
+eslint-module-utils@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
   dependencies:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-import@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"
+eslint-plugin-import@~2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
   dependencies:
     builtin-modules "^1.1.1"
     contains-path "^0.1.0"
-    debug "^2.2.0"
+    debug "^2.6.8"
     doctrine "1.5.0"
-    eslint-import-resolver-node "^0.2.0"
-    eslint-module-utils "^2.0.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.1.1"
     has "^1.0.1"
     lodash.cond "^4.3.0"
     minimatch "^3.0.3"
-    pkg-up "^1.0.0"
+    read-pkg-up "^2.0.0"
 
-eslint-plugin-node@~4.2.2:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz#c04390ab8dbcbb6887174023d6f3a72769e63b97"
+eslint-plugin-node@~5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz#80df3253c4d7901045ec87fa660a284e32bdca29"
   dependencies:
-    ignore "^3.0.11"
-    minimatch "^3.0.2"
-    object-assign "^4.0.1"
-    resolve "^1.1.7"
+    ignore "^3.3.6"
+    minimatch "^3.0.4"
+    resolve "^1.3.3"
     semver "5.3.0"
 
-eslint-plugin-promise@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
+eslint-plugin-promise@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
 
-eslint-plugin-react@~6.10.0:
-  version "6.10.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz#c5435beb06774e12c7db2f6abaddcbf900cd3f78"
+eslint-plugin-react@~7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz#52e56e8d80c810de158859ef07b880d2f56ee30b"
   dependencies:
-    array.prototype.find "^2.0.1"
-    doctrine "^1.2.2"
+    doctrine "^2.0.0"
     has "^1.0.1"
-    jsx-ast-utils "^1.3.4"
-    object.assign "^4.0.4"
+    jsx-ast-utils "^2.0.0"
+    prop-types "^15.6.0"
 
 eslint-plugin-standard@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz#34d0c915b45edc6f010393c7eef3823b08565cf2"
 
-eslint@~3.19.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+eslint-scope@^3.7.1, eslint-scope@~3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
-    babel-code-frame "^6.16.0"
-    chalk "^1.1.3"
-    concat-stream "^1.5.2"
-    debug "^2.1.1"
-    doctrine "^2.0.0"
-    escope "^3.6.0"
-    espree "^3.4.0"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@~4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.14.0.tgz#96609768d1dd23304faba2d94b7fefe5a5447a82"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.0.2"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.2"
     esquery "^1.0.0"
-    estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
-    glob "^7.0.3"
-    globals "^9.14.0"
-    ignore "^3.2.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
     imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    is-my-json-valid "^2.10.0"
+    inquirer "^3.0.6"
     is-resolvable "^1.0.0"
-    js-yaml "^3.5.1"
-    json-stable-stringify "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.0.0"
-    mkdirp "^0.5.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.1"
-    pluralize "^1.2.1"
-    progress "^1.1.8"
-    require-uncached "^1.0.2"
-    shelljs "^0.7.5"
-    strip-bom "^3.0.0"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
     strip-json-comments "~2.0.1"
-    table "^3.7.8"
+    table "^4.0.1"
     text-table "~0.2.0"
-    user-home "^2.0.0"
 
-espree@^3.4.0:
+espree@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
   dependencies:
@@ -1690,13 +1730,6 @@ ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-event-emitter@~0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
 evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -1721,10 +1754,6 @@ execa@^0.7.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
-
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -1752,6 +1781,14 @@ expect@^21.2.1:
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+
+external-editor@^2.0.4:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
 
 extglob@^0.3.1:
   version "0.3.2"
@@ -1785,12 +1822,17 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-figures@^1.3.5:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
-    escape-string-regexp "^1.0.5"
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
     object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -1918,9 +1960,13 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1934,16 +1980,6 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
-
-generate-function@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
-
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  dependencies:
-    is-property "^1.0.0"
 
 get-caller-file@^1.0.1:
   version "1.0.2"
@@ -1976,7 +2012,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1987,7 +2023,15 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.14.0, globals@^9.18.0:
+globals@^10.0.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.4.0.tgz#5c477388b128a9e4c5c5d01c7a2aca68c68b2da7"
+
+globals@^11.0.1:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
+
+globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -2153,11 +2197,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.19:
+iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ignore@^3.0.11, ignore@^3.0.9, ignore@^3.2.0:
+ignore@^3.0.9, ignore@^3.3.3, ignore@^3.3.6:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
@@ -2180,29 +2224,26 @@ ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-inquirer@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+inquirer@^3.0.6:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:
-    ansi-escapes "^1.1.0"
-    ansi-regex "^2.0.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    figures "^1.3.5"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
     lodash "^4.3.0"
-    readline2 "^1.0.1"
-    run-async "^0.1.0"
-    rx-lite "^3.1.2"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
 
-interpret@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
-
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -2290,15 +2331,6 @@ is-hex-prefixed@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
 
-is-my-json-valid@^2.10.0:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz#5a846777e2c2620d1e69104e5d3a03b1f6088f11"
-  dependencies:
-    generate-function "^2.0.0"
-    generate-object-property "^1.1.0"
-    jsonpointer "^4.0.0"
-    xtend "^4.0.0"
-
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -2335,9 +2367,9 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
-is-property@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
 is-regex@^1.0.4:
   version "1.0.4"
@@ -2349,7 +2381,7 @@ is-resolvable@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.1.tgz#acca1cd36dbe44b974b924321555a70ba03b1cf4"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2378,6 +2410,13 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2675,7 +2714,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.5.1, js-yaml@^3.7.0:
+js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2726,7 +2765,11 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+
+json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
@@ -2744,10 +2787,6 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
-
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -2757,9 +2796,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^1.3.4:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
+jsx-ast-utils@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
+  dependencies:
+    array-includes "^3.0.3"
 
 keccak@^1.0.2:
   version "1.4.0"
@@ -2833,7 +2874,7 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2841,7 +2882,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2945,7 +2986,7 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -2959,9 +3000,9 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-mute-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.2.1, nan@^2.3.0:
   version "2.8.0"
@@ -2970,6 +3011,13 @@ nan@^2.2.1, nan@^2.3.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3049,21 +3097,13 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-object-keys@^1.0.10, object-keys@^1.0.8:
+object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
-
-object.assign@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.0"
-    object-keys "^1.0.10"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -3078,9 +3118,11 @@ once@^1.3.0, once@^1.3.3, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -3112,7 +3154,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -3182,7 +3224,7 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
@@ -3255,15 +3297,9 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-pkg-up@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
-  dependencies:
-    find-up "^1.0.0"
-
-pluralize@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -3288,9 +3324,23 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-progress@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  dependencies:
+    asap "~2.0.3"
+
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 prr@~1.0.1:
   version "1.0.1"
@@ -3378,20 +3428,6 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
-
-readline2@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    mute-stream "0.0.5"
-
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  dependencies:
-    resolve "^1.1.6"
 
 regenerate@^1.2.1:
   version "1.3.3"
@@ -3517,7 +3553,7 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
-require-uncached@^1.0.2:
+require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   dependencies:
@@ -3532,18 +3568,18 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.1.7:
+resolve@^1.2.0, resolve@^1.3.3:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
     path-parse "^1.0.5"
 
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
   dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -3568,19 +3604,25 @@ rlp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.0.0.tgz#9db384ff4b89a8f61563d92395d8625b18f3afb0"
 
-run-async@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
-    once "^1.3.0"
+    is-promise "^2.1.0"
 
 run-parallel@^1.1.2:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.6.tgz#29003c9a2163e01e2d2dfc90575f2c6c1d61a039"
 
-rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -3617,20 +3659,20 @@ secp256k1@^3.0.1:
     nan "^2.2.1"
     safe-buffer "^5.1.0"
 
-semistandard@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/semistandard/-/semistandard-11.0.0.tgz#d2d9fc8ac393de21312195e006e50c8861391c47"
+semistandard@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/semistandard/-/semistandard-12.0.0.tgz#7c531cca30ce458b3444efdd0933a3bee5b4dfc0"
   dependencies:
-    eslint "~3.19.0"
-    eslint-config-semistandard "^11.0.0"
-    eslint-config-standard "^10.2.1"
-    eslint-config-standard-jsx "4.0.1"
-    eslint-plugin-import "~2.2.0"
-    eslint-plugin-node "~4.2.2"
-    eslint-plugin-promise "~3.5.0"
-    eslint-plugin-react "~6.10.0"
+    eslint "~4.14.0"
+    eslint-config-semistandard "^12.0.0"
+    eslint-config-standard "11.0.0-beta.0"
+    eslint-config-standard-jsx "~4.0.2"
+    eslint-plugin-import "~2.8.0"
+    eslint-plugin-node "~5.2.1"
+    eslint-plugin-promise "~3.6.0"
+    eslint-plugin-react "~7.5.1"
     eslint-plugin-standard "~3.0.1"
-    standard-engine "~7.0.0"
+    standard-engine "~7.2.0"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.4.1"
@@ -3647,6 +3689,10 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.9"
@@ -3665,14 +3711,6 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shelljs@^0.7.5:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
 shellwords@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -3685,9 +3723,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slice-ansi@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -3749,9 +3789,9 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-standard-engine@~7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/standard-engine/-/standard-engine-7.0.0.tgz#ebb77b9c8fc2c8165ffa353bd91ba0dff41af690"
+standard-engine@~7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/standard-engine/-/standard-engine-7.2.0.tgz#d2264d4fe880513750de38095bdc3cac9dc7738d"
   dependencies:
     deglob "^2.1.0"
     get-stdin "^5.0.1"
@@ -3773,7 +3813,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -3850,16 +3890,16 @@ sywac@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/sywac/-/sywac-1.2.0.tgz#b0a05c4e0f459918e8e42e0f55e1c1039a0e975c"
 
-table@^3.7.8:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+table@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
   dependencies:
-    ajv "^4.7.0"
-    ajv-keywords "^1.0.0"
-    chalk "^1.1.1"
-    lodash "^4.0.0"
-    slice-ansi "0.0.4"
-    string-width "^2.0.0"
+    ajv "^5.2.3"
+    ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
 
 tar-pack@^3.4.0:
   version "3.4.1"
@@ -3904,6 +3944,12 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -3911,6 +3957,10 @@ tmpl@1.0.x:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"
@@ -3954,6 +4004,10 @@ u2f-api@0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/u2f-api/-/u2f-api-0.0.9.tgz#bded457ba5a9a9ee9b58b3de291f8c1f8feacb7a"
 
+ua-parser-js@^0.7.9:
+  version "0.7.17"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+
 uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -3982,12 +4036,6 @@ url-parse-as-address@^1.0.0:
 user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
-
-user-home@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
-  dependencies:
-    os-homedir "^1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -4044,6 +4092,10 @@ whatwg-encoding@^1.0.1:
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"
   dependencies:
     iconv-lite "0.4.19"
+
+whatwg-fetch@>=0.10.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 whatwg-url@^4.3.0:
   version "4.8.0"
@@ -4120,7 +4172,7 @@ xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
-xtend@^4.0.0, xtend@^4.0.1:
+xtend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,7 +3551,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
- Create a factory function which takes as argument a JSONRPC method, and creates a MobX store out of it:
  - Create an observable that listens to the pubsub of this method.
  - Ensure singleton of stores
  - Handle errors
  - If additional `@computed/@action` is needed in this mobx store, use extendObservable on this factory function to extend it (see e.g. NodeHealthStore, or ExtraDataStore)
  - If even more fine-tuning is needed, we can still create a regular MobX store from scratch (see DevLogsStore)
  - See `src/utils/createMobxStore.js`, most important file of this PR
- Added a bunch of stores using the factory function (see README)

This PR goes in the effort of having a bunch of small modular MobX stores. If a dapp needs some MobX stores, it'd create a rootStore containing all the necessary stores, see example [here](https://github.com/paritytech/dapp-status/blob/am-new-design/src/index.js#L45-L62).
  